### PR TITLE
Update membership to v0.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ build-push-images-prod: generate-webapp
 	docker buildx build -t ${REGISTRY}/kv-mall-pricing:v0.3 $(PROJECT_DIR)pricing -f $(PROJECT_DIR)pricing/Dockerfile --platform linux/amd64,linux/arm64 --push
 	docker buildx build -t ${REGISTRY}/kv-mall-coupon:v0.4 $(PROJECT_DIR)coupon -f $(PROJECT_DIR)coupon/Dockerfile --platform linux/amd64,linux/arm64 --push
 	docker buildx build -t ${REGISTRY}/kv-mall-mail:v0.3 $(PROJECT_DIR)mail -f $(PROJECT_DIR)mail/Dockerfile --platform linux/amd64,linux/arm64 --push
-	docker buildx build -t ${REGISTRY}/kv-mall-membership:v0.3 $(PROJECT_DIR)membership -f $(PROJECT_DIR)membership/Dockerfile --platform linux/amd64,linux/arm64 --push
+	docker buildx build -t ${REGISTRY}/kv-mall-membership:v0.4 $(PROJECT_DIR)membership -f $(PROJECT_DIR)membership/Dockerfile --platform linux/amd64,linux/arm64 --push
 	docker buildx build -t ${REGISTRY}/kv-mall-analytics:v0.6 $(PROJECT_DIR)analytics -f $(PROJECT_DIR)analytics/Dockerfile --platform linux/amd64,linux/arm64 --push
 	docker buildx build -t ${REGISTRY}/kv-mall-ads:v0.3 $(PROJECT_DIR)ads -f $(PROJECT_DIR)ads/Dockerfile --platform linux/amd64,linux/arm64 --push
 	docker buildx build -t ${REGISTRY}/kv-mall-warehouse:v0.3 $(PROJECT_DIR)warehouse -f $(PROJECT_DIR)warehouse/Dockerfile --platform linux/amd64,linux/arm64 --push


### PR DESCRIPTION
The latest tag in dockerhub is 0.4: https://hub.docker.com/layers/keyval/kv-mall-membership/v0.4/images/sha256-58d7a824878d6fe436a657bf5aad1bf4e1afb6905ec1987a3b0f94cee50c1835

Updating the Makefile to that version and pushing new tag to registry.odigos.io