### PR TITLE
chore: use bitnamilegacy instead of bitnami for kafka images

### DIFF
--- a/infra/kafka-deployment.yaml
+++ b/infra/kafka-deployment.yaml
@@ -43,7 +43,7 @@ spec:
               value: CONTROLLER
             - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
               value: 'true'
-          image: bitnami/kafka:3.9
+          image: bitnamilegacy/kafka:3.9
           name: kafka
           ports:
             - containerPort: 9092

--- a/prod-deploy/kv-mall-manifest/kv-mall.yaml
+++ b/prod-deploy/kv-mall-manifest/kv-mall.yaml
@@ -539,7 +539,7 @@ spec:
               value: CONTROLLER
             - name: KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE
               value: 'true'
-          image: bitnami/kafka:3.9
+          image: bitnamilegacy/kafka:3.9
           name: kafka
           ports:
             - containerPort: 9092


### PR DESCRIPTION
The original `bitnami/kafka` images are removed

emergency-ticket id: EMR-417
